### PR TITLE
Add support to replace main NestJS Logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,15 @@ export class AppModule {}
 ```
 
 The factory might be async, can inject dependencies with `inject` option and import other modules using the `imports` option.
+
+## Use as the main Nest Logger
+
+If you want to use winston logger across the whole app, including bootstrapping and error handling, use the following:
+
+```typescript
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  app.useLogger(app.get('NestWinston'));
+}
+bootstrap();
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nest-winston",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "license": "MIT",
   "description": "A Nest module wrapper for winston",
   "keywords": [

--- a/src/winston.constants.ts
+++ b/src/winston.constants.ts
@@ -1,2 +1,3 @@
 export const WINSTON_MODULE_OPTIONS = 'WinstonModuleOptions';
 export const WINSTON_MODULE_PROVIDER = 'winston';
+export const WINSTON_MODULE_NEST_PROVIDER = 'NestWinston';

--- a/src/winston.module.spec.ts
+++ b/src/winston.module.spec.ts
@@ -3,7 +3,7 @@
 import { Injectable, Module } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { expect } from 'chai';
-import { WINSTON_MODULE_PROVIDER } from './winston.constants';
+import { WINSTON_MODULE_PROVIDER, WINSTON_MODULE_NEST_PROVIDER } from './winston.constants';
 import { WinstonModule } from './winston.module';
 
 describe('Winston module', function() {
@@ -15,6 +15,8 @@ describe('Winston module', function() {
     }).compile();
 
     expect(rootModule.get(WINSTON_MODULE_PROVIDER)).to.be.an('object');
+    expect(rootModule.get(WINSTON_MODULE_NEST_PROVIDER)).to.be.an('object');
+    expect(rootModule.get(WINSTON_MODULE_NEST_PROVIDER)).to.be.an('object');
   });
 
   it('boots successfully asynchronously', async function() {

--- a/src/winston.providers.ts
+++ b/src/winston.providers.ts
@@ -1,7 +1,27 @@
-import { Provider } from '@nestjs/common';
-import { createLogger, LoggerOptions } from 'winston';
-import { WINSTON_MODULE_OPTIONS, WINSTON_MODULE_PROVIDER } from './winston.constants';
+import { Provider, LoggerService } from '@nestjs/common';
+import { createLogger, LoggerOptions, Logger } from 'winston';
+import { WINSTON_MODULE_OPTIONS, WINSTON_MODULE_PROVIDER, WINSTON_MODULE_NEST_PROVIDER } from './winston.constants';
 import { WinstonModuleAsyncOptions, WinstonModuleOptions } from './winston.interfaces';
+
+class WinstonLogger implements LoggerService {
+  constructor(private readonly logger: Logger) { }
+
+  log(message: any, context?: string) {
+    return this.logger.info(message, context);
+  }
+  error(message: any, trace?: string, context?: string) {
+    return this.logger.error(message, trace, context);
+  }
+  warn(message: any, context?: string) {
+    return this.logger.warn(message, context);
+  }
+  debug?(message: any, context?: string) {
+    return this.logger.debug(message, context);
+  }
+  verbose?(message: any, context?: string) {
+    return this.logger.verbose(message, context);
+  }
+}
 
 export function createWinstonProviders(loggerOpts: WinstonModuleOptions): Provider[] {
   return [
@@ -9,6 +29,13 @@ export function createWinstonProviders(loggerOpts: WinstonModuleOptions): Provid
       provide: WINSTON_MODULE_PROVIDER,
       useFactory: () => createLogger(loggerOpts),
     },
+    {
+      provide: WINSTON_MODULE_NEST_PROVIDER,
+      useFactory: (logger: Logger) => {
+        return new WinstonLogger(logger);
+      },
+      inject: [WINSTON_MODULE_PROVIDER],
+    }
   ];
 }
 
@@ -23,6 +50,13 @@ export function createWinstonAsyncProviders(options: WinstonModuleAsyncOptions):
       provide: WINSTON_MODULE_PROVIDER,
       useFactory: (loggerOpts: LoggerOptions) => createLogger(loggerOpts),
       inject: [WINSTON_MODULE_OPTIONS],
+    },
+    {
+      provide: WINSTON_MODULE_NEST_PROVIDER,
+      useFactory: (logger: Logger) => {
+        return new WinstonLogger(logger);
+      },
+      inject: [WINSTON_MODULE_PROVIDER],
     },
   ];
 }


### PR DESCRIPTION
Replaces the main logger, this way you don't have two logger managed.