### PR TITLE
Create bootstrap logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The factory might be async, can inject dependencies with `inject` option and imp
 
 ## Use as the main Nest logger
 
-If you want to use winston logger across the whole app, including bootstrapping and error handling, use the following:
+If you want to use winston logger across the whole app use the following:
 
 ```typescript
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
@@ -119,3 +119,24 @@ import * as winston from 'winston';
 })
 export class AppModule {}
 ```
+
+## Use WinstonLogger as bootstrap logger
+
+When creating loggers from `WinstonModule`, Nest has to bootstrap the application first. This means instantiating all the modules and the providers, injecting dependencies, etc. During this "bootstrapping" process, instances of `WinstonLogger` are not available which means Nest falls back to an internal logger.
+
+In order to have a winston logger used during bootstrapping, the logger has to created outside of the application lifecycle and passed to `NestFactory.create` as [an option](https://docs.nestjs.com/techniques/logger) 
+
+```typescript
+import { WinstonModule } from 'nest-winston';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule, {
+    logger: WinstonModule.createLogger({
+      // same options here that would go into WinstonModule.forRoot()
+    }) 
+  });
+}
+bootstrap();
+```
+
+The bootstrapping logger will be used unless another logger is set ie: `app.useLogger()` is called.

--- a/src/winston.module.ts
+++ b/src/winston.module.ts
@@ -1,6 +1,6 @@
-import { DynamicModule, Global, Module } from '@nestjs/common';
+import { DynamicModule, Global, LoggerService, Module } from '@nestjs/common';
 import { WinstonModuleAsyncOptions, WinstonModuleOptions } from './winston.interfaces';
-import { createWinstonAsyncProviders, createWinstonProviders } from './winston.providers';
+import { createNestWinstonLogger, createWinstonAsyncProviders, createWinstonProviders } from './winston.providers';
 
 @Global()
 @Module({})
@@ -24,5 +24,9 @@ export class WinstonModule {
       providers: providers,
       exports: providers,
     };
+  }
+
+  public static createLogger(options: WinstonModuleOptions): LoggerService {
+    return createNestWinstonLogger(options);
   }
 }

--- a/src/winston.providers.ts
+++ b/src/winston.providers.ts
@@ -27,6 +27,10 @@ class WinstonLogger implements LoggerService {
   }
 }
 
+export function createNestWinstonLogger(loggerOpts: WinstonModuleOptions): WinstonLogger {
+  return new WinstonLogger(createLogger(loggerOpts));
+}
+
 export function createWinstonProviders(loggerOpts: WinstonModuleOptions): Provider[] {
   return [
     {


### PR DESCRIPTION
This addresses #44 by providing the ability to instantiate a `WinstonLogger` to be used as the Nest logger when bootstrapping the application.