### PR TITLE
implemented possibility to boot module asynchronously via useClass option, README and tests updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ export class AppModule {}
 
 The factory might be async, can inject dependencies with `inject` option and import other modules using the `imports` option.
 
+Alternatively, you can use the `useClass` syntax:
+```
+WinstonModule.forRootAsync({
+  useClass: WinstonConfigService,
+})
+```
+
 ## Use as the main Nest logger
 
 If you want to use winston logger across the whole app, including bootstrapping and error handling, use the following:

--- a/src/winston.interfaces.ts
+++ b/src/winston.interfaces.ts
@@ -1,11 +1,17 @@
+import { Type } from '@nestjs/common';
 import { ModuleMetadata } from '@nestjs/common/interfaces';
 import { LoggerOptions } from 'winston';
 
 export type WinstonModuleOptions = LoggerOptions;
 
+export interface WinstonModuleOptionsFactory {
+  createWinstonModuleOptions(): Promise<WinstonModuleOptions> | WinstonModuleOptions;
+}
+
 export interface WinstonModuleAsyncOptions extends Pick<ModuleMetadata, 'imports'> {
-  useFactory: (
+  useFactory?: (
     ...args: any[]
   ) => Promise<WinstonModuleOptions> | WinstonModuleOptions;
   inject?: any[];
+  useClass?: Type<WinstonModuleOptionsFactory>;
 }

--- a/src/winston.module.spec.ts
+++ b/src/winston.module.spec.ts
@@ -5,6 +5,7 @@ import { Test } from '@nestjs/testing';
 import { expect } from 'chai';
 import { WINSTON_MODULE_NEST_PROVIDER, WINSTON_MODULE_PROVIDER } from './winston.constants';
 import { WinstonModule } from './winston.module';
+import {WinstonModuleOptions, WinstonModuleOptionsFactory} from './winston.interfaces';
 
 describe('Winston module', function() {
   it('boots successfully', async function() {
@@ -18,7 +19,7 @@ describe('Winston module', function() {
     expect(rootModule.get(WINSTON_MODULE_NEST_PROVIDER)).to.be.an('object');
   });
 
-  it('boots successfully asynchronously', async function() {
+  it('boots successfully asynchronously via useFactory', async function() {
     @Injectable()
     class ConfigService {
       public loggerOptions = {};
@@ -36,6 +37,37 @@ describe('Winston module', function() {
           imports: [FeatureModule],
           useFactory: (cfg: ConfigService) => cfg.loggerOptions,
           inject: [ConfigService],
+        }),
+      ],
+    }).compile();
+
+    const app = rootModule.createNestApplication();
+    await app.init();
+
+    expect(rootModule.get(WINSTON_MODULE_PROVIDER)).to.be.an('object');
+    expect(rootModule.get(WINSTON_MODULE_NEST_PROVIDER)).to.be.an('object');
+  });
+
+  it('boots successfully asynchronously via useClass', async function() {
+    @Injectable()
+    class ConfigService implements WinstonModuleOptionsFactory {
+      private loggerOptions = {};
+
+      createWinstonModuleOptions(): WinstonModuleOptions {
+        return this.loggerOptions;
+      }
+    }
+
+    @Module({
+      providers: [ConfigService],
+      exports: [ConfigService],
+    })
+    class FeatureModule {}
+
+    const rootModule = await Test.createTestingModule({
+      imports: [
+        WinstonModule.forRootAsync({
+          useClass: ConfigService,
         }),
       ],
     }).compile();

--- a/src/winston.module.ts
+++ b/src/winston.module.ts
@@ -23,6 +23,6 @@ export class WinstonModule {
       imports: options.imports,
       providers: providers,
       exports: providers,
-    };
+    } as DynamicModule;
   }
 }

--- a/src/winston.providers.ts
+++ b/src/winston.providers.ts
@@ -1,7 +1,7 @@
-import { LoggerService, Provider } from '@nestjs/common';
+import {LoggerService, Provider, Type} from '@nestjs/common';
 import { createLogger, Logger, LoggerOptions } from 'winston';
 import { WINSTON_MODULE_NEST_PROVIDER, WINSTON_MODULE_OPTIONS, WINSTON_MODULE_PROVIDER } from './winston.constants';
-import { WinstonModuleAsyncOptions, WinstonModuleOptions } from './winston.interfaces';
+import {WinstonModuleAsyncOptions, WinstonModuleOptions, WinstonModuleOptionsFactory} from './winston.interfaces';
 
 class WinstonLogger implements LoggerService {
   constructor(private readonly logger: Logger) { }
@@ -44,12 +44,7 @@ export function createWinstonProviders(loggerOpts: WinstonModuleOptions): Provid
 }
 
 export function createWinstonAsyncProviders(options: WinstonModuleAsyncOptions): Provider[] {
-  return [
-    {
-      provide: WINSTON_MODULE_OPTIONS,
-      useFactory: options.useFactory,
-      inject: options.inject || [],
-    },
+  const providers: Provider[] = [
     {
       provide: WINSTON_MODULE_PROVIDER,
       useFactory: (loggerOpts: LoggerOptions) => createLogger(loggerOpts),
@@ -63,4 +58,32 @@ export function createWinstonAsyncProviders(options: WinstonModuleAsyncOptions):
       inject: [WINSTON_MODULE_PROVIDER],
     },
   ];
+
+  if (options.useClass) {
+    const useClass = options.useClass as Type<WinstonModuleOptionsFactory>;
+    providers.push(...[
+      {
+        provide: WINSTON_MODULE_OPTIONS,
+        useFactory: async (optionsFactory: WinstonModuleOptionsFactory) =>
+          await optionsFactory.createWinstonModuleOptions(),
+        inject: [useClass],
+      },
+      {
+        provide: useClass,
+        useClass,
+      }
+    ]);
+  }
+
+  if (options.useFactory) {
+    providers.push(
+      {
+        provide: WINSTON_MODULE_OPTIONS,
+        useFactory: options.useFactory,
+        inject: options.inject || [],
+      },
+    );
+  }
+
+  return providers;
 }


### PR DESCRIPTION
Just for the case when it's convenient to separate all your logic into a separate class and you don't want to write cumbersome `useFactory` syntax

Alternatively, you can use the `useClass` syntax:
```
WinstonModule.forRootAsync({
  useClass: WinstonConfigService,
})
```