### PR TITLE
export WinstonLogger

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './winston.constants';
 export * from './winston.interfaces';
 export * from './winston.module';
+export * from './winston.providers';
 export * from './winston.utilities';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export * from './winston.constants';
+export * from './winston.interfaces';
 export * from './winston.module';
 export * from './winston.utilities';
-export * from './winston.interfaces';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './winston.constants';
 export * from './winston.module';
 export * from './winston.utilities';
+export * from './winston.interfaces';

--- a/src/winston.providers.ts
+++ b/src/winston.providers.ts
@@ -3,7 +3,7 @@ import { createLogger, Logger, LoggerOptions } from 'winston';
 import { WINSTON_MODULE_NEST_PROVIDER, WINSTON_MODULE_OPTIONS, WINSTON_MODULE_PROVIDER } from './winston.constants';
 import { WinstonModuleAsyncOptions, WinstonModuleOptions, WinstonModuleOptionsFactory } from './winston.interfaces';
 
-class WinstonLogger implements LoggerService {
+export class WinstonLogger implements LoggerService {
   constructor(private readonly logger: Logger) { }
 
   public log(message: any, context?: string) {


### PR DESCRIPTION
case with 
```
import {Logger} from "winston";
import {WINSTON_MODULE_PROVIDER} from "nest-winston";

@Inject(WINSTON_MODULE_PROVIDER) private readonly logger: Logger,
```
works good 

but when I want to use
```
@Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: WinstonLogger,
```
`WinstonLogger` is not exported from `nest-winston`, and even `LoggerService` is not exported from `@nestjs/core` so there is no suitable type :(
