### PR TITLE
Add "context" property to WinstonLogger

### DIFF
--- a/src/winston.providers.ts
+++ b/src/winston.providers.ts
@@ -4,26 +4,32 @@ import { WINSTON_MODULE_NEST_PROVIDER, WINSTON_MODULE_OPTIONS, WINSTON_MODULE_PR
 import { WinstonModuleAsyncOptions, WinstonModuleOptions, WinstonModuleOptionsFactory } from './winston.interfaces';
 
 class WinstonLogger implements LoggerService {
+  private context?: string;
+
   constructor(private readonly logger: Logger) { }
 
+  public setContext(context: string) {
+    this.context = context;
+  }
+
   public log(message: any, context?: string) {
-    return this.logger.info(message, { context });
+    return this.logger.info(message, {context: context || this.context});
   }
 
   public error(message: any, trace?: string, context?: string): any {
-    return this.logger.error(message, { trace, context });
+    return this.logger.error(message, {trace, context: context || this.context});
   }
 
   public warn(message: any, context?: string): any {
-    return this.logger.warn(message, { context });
+    return this.logger.warn(message, {context: context || this.context});
   }
 
   public debug?(message: any, context?: string): any {
-    return this.logger.debug(message, { context });
+    return this.logger.debug(message, {context: context || this.context});
   }
 
   public verbose?(message: any, context?: string): any {
-    return this.logger.verbose(message, { context });
+    return this.logger.verbose(message, {context: context || this.context});
   }
 }
 


### PR DESCRIPTION
https://github.com/gremo/nest-winston/issues/122
Add private property "context" and corresponding setter to WinstonLogger.

Improve all logging methods inside WinstonLogger to use private property context's value if there is no context passed explicitly.