### PR TITLE
alllow meta in WinstonLogger

### DIFF
--- a/src/winston.classes.ts
+++ b/src/winston.classes.ts
@@ -11,23 +11,38 @@ export class WinstonLogger implements LoggerService {
     this.context = context;
   }
 
-  public log(message: any, context?: string) {
-    return this.logger.info(message, { context: context || this.context });
+  public log(message: any, meta?: string | Record<string, unknown>) {
+    if('object' === typeof meta) {
+      return this.logger.info(message, { context: this.context, ...meta });
+    }
+    return this.logger.info(message, { context: meta || this.context, });
   }
 
-  public error(message: any, trace?: string, context?: string): any {
-    return this.logger.error(message, { trace, context: context || this.context });
+  public error(message: any, trace?: string, meta?: string | Record<string, unknown>): any {
+    if('object' === typeof meta) {
+      return this.logger.error(message, { trace, context: this.context, ...meta });
+    }
+    return this.logger.error(message, { trace, context: meta || this.context });
   }
 
-  public warn(message: any, context?: string): any {
-    return this.logger.warn(message, { context: context || this.context });
+  public warn(message: any, meta?: string | Record<string, unknown>): any {
+    if('object' === typeof meta) {
+      return this.logger.warn(message, { context: this.context, ...meta });
+    }
+    return this.logger.warn(message, { context: meta || this.context });
   }
 
-  public debug?(message: any, context?: string): any {
-    return this.logger.debug(message, { context: context || this.context });
+  public debug?(message: any, meta?: string | Record<string, unknown>): any {
+    if('object' === typeof meta) {
+      return this.logger.debug(message, { context: this.context, ...meta });
+    }
+    return this.logger.debug(message, { context: meta || this.context });
   }
 
-  public verbose?(message: any, context?: string): any {
-    return this.logger.verbose(message, { context: context || this.context });
+  public verbose?(message: any, meta?: string | Record<string, unknown>): any {
+    if('object' === typeof meta) {
+      return this.logger.verbose(message, { context: this.context, ...meta });
+    }
+    return this.logger.verbose(message, { context: meta || this.context });
   }
 }

--- a/src/winston.utilities.ts
+++ b/src/winston.utilities.ts
@@ -4,12 +4,17 @@ import { format } from 'winston';
 import safeStringify from 'fast-safe-stringify';
 
 const nestLikeConsoleFormat = (appName = 'NestWinston'): Format => format.printf(({ context, level, timestamp, message, ...meta }) => {
-  return `${green(`[${appName}]`)} ` +
+  let content = `${green(`[${appName}]`)} ` +
          `${yellow(level.charAt(0).toUpperCase() + level.slice(1))}\t` +
          ('undefined' !== typeof timestamp ? `${new Date(timestamp).toLocaleString()} ` : '') +
          ('undefined' !== typeof context ? `${yellow('[' + context + ']')} ` : '') +
-         `${green(message)} - ` +
-         `${safeStringify(meta)}`;
+         `${green(message)}`
+
+  if(!(0 === Object.keys(meta).length && meta.constructor === Object)) {
+    content = content + ` - ${safeStringify(meta)}`;
+  }
+
+  return content
 });
 
 export const utilities = {


### PR DESCRIPTION
- Allow meta data other than context in `WinstonLogger`
- Avoid printing an empty object in WinstonLogger in `nestLike` format