### PR TITLE
Allow metadata support without breaking Nest interface

### DIFF
--- a/src/winston.classes.ts
+++ b/src/winston.classes.ts
@@ -16,8 +16,10 @@ export class WinstonLogger implements LoggerService {
 
     if('object' === typeof message) {
       const { message: msg, ...meta } = message;
+
       return this.logger.info(msg as string, { context, ...meta });
     }
+
     return this.logger.info(message, { context });
   }
 
@@ -25,12 +27,15 @@ export class WinstonLogger implements LoggerService {
     context = context || this.context;
 
     if(message instanceof Error) {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { message: msg, name, stack, ...meta } = message;
+
       return this.logger.error(msg, { context, stack: [trace || message.stack], ...meta });
     }
 
     if('object' === typeof message) {
       const { message: msg, ...meta } = message;
+
       return this.logger.error(msg as string, { context, stack: [trace], ...meta });
     }
 
@@ -42,8 +47,10 @@ export class WinstonLogger implements LoggerService {
 
     if('object' === typeof message) {
       const { message: msg, ...meta } = message;
+
       return this.logger.warn(msg as string, { context, ...meta });
     }
+
     return this.logger.warn(message, { context });
   }
 
@@ -52,8 +59,10 @@ export class WinstonLogger implements LoggerService {
 
     if('object' === typeof message) {
       const { message: msg, ...meta } = message;
+
       return this.logger.debug(msg as string, { context, ...meta });
     }
+
     return this.logger.debug(message, { context });
   }
 
@@ -62,8 +71,10 @@ export class WinstonLogger implements LoggerService {
 
     if('object' === typeof message) {
       const { message: msg, ...meta } = message;
+
       return this.logger.verbose(msg as string, { context, ...meta });
     }
+
     return this.logger.verbose(message, { context });
   }
 }

--- a/src/winston.classes.ts
+++ b/src/winston.classes.ts
@@ -11,23 +11,59 @@ export class WinstonLogger implements LoggerService {
     this.context = context;
   }
 
-  public log(message: any, context?: string) {
-    return this.logger.info(message, { context: context || this.context });
+  public log(message: any, context?: string): any {
+    context = context || this.context;
+
+    if('object' === typeof message) {
+      const { message: msg, ...meta } = message;
+      return this.logger.info(msg as string, { context, ...meta });
+    }
+    return this.logger.info(message, { context });
   }
 
   public error(message: any, trace?: string, context?: string): any {
-    return this.logger.error(message, { trace, context: context || this.context });
+    context = context || this.context;
+
+    if(message instanceof Error) {
+      const { message: msg, name, stack, ...meta } = message;
+      return this.logger.error(msg, { context, stack: [trace || message.stack], ...meta });
+    }
+
+    if('object' === typeof message) {
+      const { message: msg, ...meta } = message;
+      return this.logger.error(msg as string, { context, stack: [trace], ...meta });
+    }
+
+    return this.logger.error(message, { context, stack: [trace] });
   }
 
   public warn(message: any, context?: string): any {
-    return this.logger.warn(message, { context: context || this.context });
+    context = context || this.context;
+
+    if('object' === typeof message) {
+      const { message: msg, ...meta } = message;
+      return this.logger.warn(msg as string, { context, ...meta });
+    }
+    return this.logger.warn(message, { context });
   }
 
   public debug?(message: any, context?: string): any {
-    return this.logger.debug(message, { context: context || this.context });
+    context = context || this.context;
+
+    if('object' === typeof message) {
+      const { message: msg, ...meta } = message;
+      return this.logger.debug(msg as string, { context, ...meta });
+    }
+    return this.logger.debug(message, { context });
   }
 
   public verbose?(message: any, context?: string): any {
-    return this.logger.verbose(message, { context: context || this.context });
+    context = context || this.context;
+
+    if('object' === typeof message) {
+      const { message: msg, ...meta } = message;
+      return this.logger.verbose(msg as string, { context, ...meta });
+    }
+    return this.logger.verbose(message, { context });
   }
 }


### PR DESCRIPTION
Hi! I've made the PR to add metadata support, but not breaking the Nest `LoggerService` interface.
I was motivated by the #191 . 

Have tested these changes in my project with `stdout` and (optional) Google Cloud StackDrive Logging and Error Reporting with `@google-cloud/logging-winston` library.

**Logging usage examples (standard interface):**
```typescript
this.logger.log('Inline message');
this.logger.debug({ message: 'Message and meta', foo: bar });
```

**Error logging usage examples (standard interface):**
```typescript
// These won't be sent to Error Reporting, as no error stack trace available
this.logger.error('Inline error no trace');
this.logger.error({ message: 'Message object no trace', foo: 'bar' });

// Generate stack trace
const targetObject: { stack?: string } = { };
Error.captureStackTrace(targetObject);
targetObject.stack;  // Similar to `new Error().stack`

// These errors would be sent to Error Reporting,
// since 'stack' is available
this.logger.error({ message: 'Message object with stack trace', foo: 'bar' }, targetObject.stack);
this.logger.error(new Error('Error object'));
this.logger.error(new ExtendedError('Extended error', 'foo', 42));
```

Example implementation of `ExtendedError`:
```typescript
class ExtendedError extends Error {
    constructor(
        message: string,
        private readonly prop1: string,
        private readonly prop2: number
    ) {
        super(message); // 'Error' breaks prototype chain here
        Object.setPrototypeOf(this, new.target.prototype); // restore prototype chain
    }
}
```