### PR TITLE
chore: fix renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,10 +10,5 @@
       ],
       "rangeStrategy": "bump"
     }
-  ],
-  "force": {
-    "constraints": {
-      "node": "< 15.0.0"
-    }
-  }
+  ]
 }


### PR DESCRIPTION
Remove constraints so renovate can autodetect by lockfile version