### PR TITLE
Add prettyPrint option to nestLikeConsoleFormat

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ import * as winston from 'winston';
           format: winston.format.combine(
             winston.format.timestamp(),
             winston.format.ms(),
-            nestWinstonModuleUtilities.format.nestLike(),
+            nestWinstonModuleUtilities.format.nestLike('MyApp', { prettyPrint: true }),
           ),
         }),
         // other transports...

--- a/src/winston.interfaces.ts
+++ b/src/winston.interfaces.ts
@@ -4,6 +4,10 @@ import { Type } from '@nestjs/common';
 
 export type WinstonModuleOptions = LoggerOptions;
 
+export type NestLikeConsoleFormatOptions = {
+  prettyPrint: boolean;
+};
+
 export interface WinstonModuleOptionsFactory {
   createWinstonModuleOptions(): Promise<WinstonModuleOptions> | WinstonModuleOptions;
 }

--- a/src/winston.utilities.ts
+++ b/src/winston.utilities.ts
@@ -1,7 +1,9 @@
 import { Format } from 'logform';
+import { NestLikeConsoleFormatOptions } from './winston.interfaces';
 import bare from 'cli-color/bare';
 import clc from 'cli-color';
 import { format } from 'winston';
+import { inspect } from 'util';
 import safeStringify from 'fast-safe-stringify';
 
 const nestLikeColorScheme: Record<string, bare.Format> = {
@@ -12,29 +14,43 @@ const nestLikeColorScheme: Record<string, bare.Format> = {
   verbose: clc.cyanBright,
 };
 
-const nestLikeConsoleFormat = (appName = 'NestWinston'): Format => format.printf(({ context, level, timestamp, message, ms, ...meta }) => {
-  if ('undefined' !== typeof timestamp) {
-    // Only format the timestamp to a locale representation if it's ISO 8601 format. Any format
-    // that is not a valid date string will throw, just ignore it (it will be printed as-is).
-    try {
-      if (timestamp === (new Date(timestamp)).toISOString()) {
-        timestamp = (new Date(timestamp)).toLocaleString();
+const nestLikeConsoleFormat = (
+  appName = 'NestWinston',
+  options?: NestLikeConsoleFormatOptions
+): Format =>
+  format.printf(({ context, level, timestamp, message, ms, ...meta }) => {
+    if ('undefined' !== typeof timestamp) {
+      // Only format the timestamp to a locale representation if it's ISO 8601 format. Any format
+      // that is not a valid date string will throw, just ignore it (it will be printed as-is).
+      try {
+        if (timestamp === new Date(timestamp).toISOString()) {
+          timestamp = new Date(timestamp).toLocaleString();
+        }
+      } catch (error) {
+        // eslint-disable-next-line no-empty
       }
-    } catch (error) { // eslint-disable-next-line no-empty
     }
-  }
 
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-  const color = nestLikeColorScheme[level] || ((text: string): string => text);
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    const color = nestLikeColorScheme[level] || ((text: string): string => text);
 
-  return `${color(`[${appName}]`)} ` +
-         `${clc.yellow(level.charAt(0).toUpperCase() + level.slice(1))}\t` +
-         ('undefined' !== typeof timestamp ? `${timestamp} ` : '') +
-         ('undefined' !== typeof context ? `${clc.yellow('[' + context + ']')} ` : '') +
-         `${color(message)} - ` +
-         `${safeStringify(meta)}` +
-         ('undefined' !== typeof ms ? ` ${clc.yellow(ms)}` : '');
-});
+    const stringifiedMeta = safeStringify(meta);
+    const formattedMeta = options?.prettyPrint
+      ? inspect(JSON.parse(stringifiedMeta), { colors: true, depth: null })
+      : stringifiedMeta;
+
+    return (
+      `${color(`[${appName}]`)} ` +
+      `${clc.yellow(level.charAt(0).toUpperCase() + level.slice(1))}\t` +
+      ('undefined' !== typeof timestamp ? `${timestamp} ` : '') +
+      ('undefined' !== typeof context
+        ? `${clc.yellow('[' + context + ']')} `
+        : '') +
+      `${color(message)} - ` +
+      `${formattedMeta}` +
+      ('undefined' !== typeof ms ? ` ${clc.yellow(ms)}` : '')
+    );
+  });
 
 export const utilities = {
   format: {


### PR DESCRIPTION
Allow to pass an options object to `nestLike` formatter containing prettyPrint key. The prettyPrint option will apply util.inspect ([like winston](https://github.com/winstonjs/logform#prettyprint)) on the meta object.

Without prettyPrint:
```typescript
new winston.transports.Console({
  format: winston.format.combine(
    winston.format.timestamp(),
    nestWinstonModuleUtilities.format.nestLike('MyTestApp'),
  ),
}),
```
![image](https://user-images.githubusercontent.com/6771601/135106486-a7bf2f5a-2476-44a0-895e-5f916f16c9e2.png)
With prettyPrint:
```typescript
new winston.transports.Console({
  format: winston.format.combine(
    winston.format.timestamp(),
    nestWinstonModuleUtilities.format.nestLike('MyTestApp', { prettyPrint: true }),
  ),
}),
```
![image](https://user-images.githubusercontent.com/6771601/135106645-1306416b-f7cc-421c-bb6a-bcfb703c89cc.png)
