### PR TITLE
Exposing winston logger for use in other packages

### DIFF
--- a/src/winston.classes.ts
+++ b/src/winston.classes.ts
@@ -77,4 +77,8 @@ export class WinstonLogger implements LoggerService {
 
     return this.logger.verbose(message, { context });
   }
+
+  public getWinstonLogger(): Logger {
+    return this.logger;
+  }
 }


### PR DESCRIPTION
I wish I could use the same logger in other packages (e.g: https://github.com/minddocdev/nest-express-winston), but currently the logger is private and there is no way to access it.

To use it I need to access the same `Logger` object, but it is currently private. I noticed that the createNestWinstonLogger function just creates an object so I just added a function to export the `Logger`.

After that, it is possible to use the same logger in other midwares or packages.

```ts
const logger = WinstonModule.createLogger({/*... No changes here ...*/ });
const configs: NestApplicationOptions = {logger};
const app = await NestFactory.create(AppModule, {logger});

// adding logger in another function 
const expressWinstonHandler = createExpressWinstonHandler(logger.getWinstonLogger());
app.use(expressWinstonHandler);
// ...

```