### PR TITLE
fix: Context is lost when logging errors (fixes #473)

### DIFF
--- a/src/winston.classes.ts
+++ b/src/winston.classes.ts
@@ -24,6 +24,10 @@ export class WinstonLogger implements LoggerService {
   }
 
   public error(message: any, trace?: string, context?: string): any {
+    if (context === undefined) {
+      context = trace;
+      trace = undefined;
+    }
     context = context || this.context;
 
     if(message instanceof Error) {


### PR DESCRIPTION
See discussion in #473.

The downside of this PR is that it will break anyone who was previously using `WinstonLogger.error(message, trace)` because it will now be interpreted as `WinstonLogger.error(message, stack)`.

But it will fix the more common use case of `Logger.error(message)` not losing context.