### PR TITLE
Updated actions workflow for latest NestJS major version 9

### DIFF
--- a/.github/workflows/test-on-push.yml
+++ b/.github/workflows/test-on-push.yml
@@ -9,13 +9,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['10', '12', '14', '16']
-        nest-version: ['5', '6', '7', '']
+        node-version: ['12', '14', '16']
+        nest-version: ['5', '6', '7', '8', '']
         include:
           - { node-version: '8.9.0', nest-version: '5' }
           - { node-version: '8.9.0', nest-version: '6' }
           - { node-version: '8.9.0', nest-version: '7' }
-          - { node-version: '8.9.0', nest-version: '' }
+          - { node-version: '10', nest-version: '5' }
+          - { node-version: '10', nest-version: '6' }
+          - { node-version: '10', nest-version: '7' }
+          - { node-version: '10', nest-version: '8' }
 
     steps:
       - name: Checkout

--- a/.github/workflows/test-on-push.yml
+++ b/.github/workflows/test-on-push.yml
@@ -43,7 +43,8 @@ jobs:
       - name: Install platform-express
         if: >-
           startsWith(matrix.nest-version, '6') ||
-          startsWith(matrix.nest-version, '7')
+          startsWith(matrix.nest-version, '7') ||
+          startsWith(matrix.nest-version, '8')
         run: npm install @nestjs/platform-express@^${{ matrix.nest-version }}
 
       # nestjs 5.x-7.x supports rxjs 6.x


### PR DESCRIPTION
Changes:
* Updated actions workflow `test-on-push` to support v9 major release of NestJS which drops support for NodeJS v10.
  * Removed NodeJS v10 from base `node-version` matrix as it is no longer supported by the latest version of NestJS.
  * Removed test matrix combination for NestJS latest version (`''`) and NodeJS v8.9.0 as it is no longer supported by the latest version of NestJS.
  * Added explicit matrix combinations for Node v10 and NestJS versions 5, 6, 7, and 8.