### PR TITLE
Turn off colorization in nestLike for context section

### DIFF
--- a/src/winston.utilities.ts
+++ b/src/winston.utilities.ts
@@ -55,7 +55,7 @@ const nestLikeConsoleFormat = (
       `${yellow(level.charAt(0).toUpperCase() + level.slice(1))}\t` +
       ('undefined' !== typeof timestamp ? `${timestamp} ` : '') +
       ('undefined' !== typeof context
-        ? `${clc.yellow('[' + context + ']')} `
+        ? `${yellow('[' + context + ']')} `
         : '') +
       `${color(message)} - ` +
       `${formattedMeta}` +


### PR DESCRIPTION
When using NO_COLORS=false environment variable, disable the color inside all text, even for context.

Keeping the color in the context section, breaks logs systems that only work with plain text

Log from cloudwatch before changes:
`[accounts] Info    2022-09-22T17:10:40.785+00:00 [33m[HTTP] [39m method=GET | path=/health | status=200`

Log from cloudwatch after changes:
`[accounts] Info    2022-09-23T11:05:30.247+00:00 [HTTP] method=GET | path=/health | status=200`
