### PR TITLE
use instance from module options in all providers

### DIFF
--- a/src/winston.module.spec.ts
+++ b/src/winston.module.spec.ts
@@ -1,22 +1,27 @@
-import { Injectable, Module } from '@nestjs/common';
-import { Test } from '@nestjs/testing';
-import { WINSTON_MODULE_NEST_PROVIDER, WINSTON_MODULE_PROVIDER } from './winston.constants';
-import { WinstonModuleOptions, WinstonModuleOptionsFactory } from './winston.interfaces';
-import { WinstonModule } from './winston.module';
+import { Injectable, Module } from "@nestjs/common";
+import { Test } from "@nestjs/testing";
+import { Logger } from "winston";
+import {
+  WINSTON_MODULE_NEST_PROVIDER,
+  WINSTON_MODULE_PROVIDER,
+} from "./winston.constants";
+import {
+  WinstonModuleOptions,
+  WinstonModuleOptionsFactory,
+} from "./winston.interfaces";
+import { WinstonModule } from "./winston.module";
 
-describe('Winston module', function () {
-  it('boots successfully', async function () {
+describe("Winston module", function () {
+  it("boots successfully", async function () {
     const rootModule = await Test.createTestingModule({
-      imports: [
-        WinstonModule.forRoot({}),
-      ],
+      imports: [WinstonModule.forRoot({})],
     }).compile();
 
     expect(rootModule.get(WINSTON_MODULE_PROVIDER)).toBeDefined();
     expect(rootModule.get(WINSTON_MODULE_NEST_PROVIDER)).toBeDefined();
   });
 
-  it('boots successfully asynchronously via useFactory', async function () {
+  it("boots successfully asynchronously via useFactory", async function () {
     @Injectable()
     class ConfigService {
       public loggerOptions = {};
@@ -45,7 +50,7 @@ describe('Winston module', function () {
     expect(rootModule.get(WINSTON_MODULE_NEST_PROVIDER)).toBeDefined();
   });
 
-  it('boots successfully asynchronously via useClass', async function () {
+  it("boots successfully asynchronously via useClass", async function () {
     @Injectable()
     class ConfigService implements WinstonModuleOptionsFactory {
       private loggerOptions = {};
@@ -68,5 +73,80 @@ describe('Winston module', function () {
 
     expect(rootModule.get(WINSTON_MODULE_PROVIDER)).toBeDefined();
     expect(rootModule.get(WINSTON_MODULE_NEST_PROVIDER)).toBeDefined();
+  });
+
+  describe("instance in module options", () => {
+    let mockLogger: Logger;
+
+    beforeEach(() => {
+      mockLogger = {} as Logger;
+    });
+
+    it("boots successfully", async function () {
+      const rootModule = await Test.createTestingModule({
+        imports: [WinstonModule.forRoot({ instance: mockLogger })],
+      }).compile();
+
+      expect(rootModule.get(WINSTON_MODULE_PROVIDER)).toBe(mockLogger);
+      expect(rootModule.get(WINSTON_MODULE_NEST_PROVIDER)).toEqual(
+        expect.objectContaining({ logger: mockLogger })
+      );
+    });
+
+    it("boots successfully asynchronously via useFactory", async function () {
+      @Injectable()
+      class ConfigService {
+        public loggerOptions = { instance: mockLogger };
+      }
+
+      @Module({
+        providers: [ConfigService],
+        exports: [ConfigService],
+      })
+      class FeatureModule {}
+
+      const rootModule = await Test.createTestingModule({
+        imports: [
+          WinstonModule.forRootAsync({
+            imports: [FeatureModule],
+            useFactory: (cfg: ConfigService) => cfg.loggerOptions,
+            inject: [ConfigService],
+          }),
+        ],
+      }).compile();
+
+      const app = rootModule.createNestApplication();
+      await app.init();
+
+      expect(rootModule.get(WINSTON_MODULE_PROVIDER)).toBe(mockLogger);
+      expect(rootModule.get(WINSTON_MODULE_NEST_PROVIDER)).toEqual(
+        expect.objectContaining({ logger: mockLogger })
+      );
+    });
+
+    it("boots successfully asynchronously via useClass", async function () {
+      @Injectable()
+      class ConfigService implements WinstonModuleOptionsFactory {
+        private loggerOptions = { instance: mockLogger };
+
+        public createWinstonModuleOptions(): WinstonModuleOptions {
+          return this.loggerOptions;
+        }
+      }
+
+      const rootModule = await Test.createTestingModule({
+        imports: [
+          WinstonModule.forRootAsync({
+            useClass: ConfigService,
+          }),
+        ],
+      }).compile();
+
+      const app = rootModule.createNestApplication();
+      await app.init();
+
+      expect(rootModule.get(WINSTON_MODULE_PROVIDER)).toBe(mockLogger);
+      expect(rootModule.get(WINSTON_MODULE_NEST_PROVIDER)).toEqual(expect.objectContaining({logger: mockLogger}))
+    });
   });
 });

--- a/src/winston.providers.ts
+++ b/src/winston.providers.ts
@@ -1,4 +1,4 @@
-import { Logger, LoggerOptions, createLogger } from 'winston';
+import { Logger, createLogger } from 'winston';
 import { Provider, Type } from '@nestjs/common';
 import { WINSTON_MODULE_NEST_PROVIDER, WINSTON_MODULE_OPTIONS, WINSTON_MODULE_PROVIDER } from './winston.constants';
 import { WinstonModuleAsyncOptions, WinstonModuleOptions, WinstonModuleOptionsFactory } from './winston.interfaces';
@@ -15,7 +15,7 @@ export function createWinstonProviders(loggerOpts: WinstonModuleOptions): Provid
   return [
     {
       provide: WINSTON_MODULE_PROVIDER,
-      useFactory: () => createLogger(loggerOpts),
+      useFactory: () => (loggerOpts.instance) || createLogger(loggerOpts),
     },
     {
       provide: WINSTON_MODULE_NEST_PROVIDER,
@@ -31,7 +31,7 @@ export function createWinstonAsyncProviders(options: WinstonModuleAsyncOptions):
   const providers: Provider[] = [
     {
       provide: WINSTON_MODULE_PROVIDER,
-      useFactory: (loggerOpts: LoggerOptions) => createLogger(loggerOpts),
+      useFactory: (loggerOpts: WinstonModuleOptions) => (loggerOpts.instance) || createLogger(loggerOpts),
       inject: [WINSTON_MODULE_OPTIONS],
     },
     {


### PR DESCRIPTION
This PR follows on from the changes [PR585](https://github.com/gremo/nest-winston/pull/585) which introduced the `instance` field in `WinstonModuleOptions`.

Although the `instance` was being used in the `createNestWinstonLogger` method, it was ignored by the other providers.

With this change, if the `instance` is set in the options, it will be used by all the providers. 