### PR TITLE
Pass original message object in meta data

### DIFF
--- a/src/winston.classes.ts
+++ b/src/winston.classes.ts
@@ -17,7 +17,7 @@ export class WinstonLogger implements LoggerService {
     if('object' === typeof message) {
       const { message: msg, ...meta } = message;
 
-      return this.logger.info(msg as string, { context, ...meta });
+      return this.logger.info(msg as string, { context, value: message, ...meta });
     }
 
     return this.logger.info(message, { context });
@@ -30,13 +30,13 @@ export class WinstonLogger implements LoggerService {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { message: msg, name, stack, ...meta } = message;
 
-      return this.logger.error(msg, { context, stack: [trace || message.stack], ...meta });
+      return this.logger.error(msg, { context, stack: [trace || message.stack], value: message, ...meta });
     }
 
     if('object' === typeof message) {
       const { message: msg, ...meta } = message;
 
-      return this.logger.error(msg as string, { context, stack: [trace], ...meta });
+      return this.logger.error(msg as string, { context, stack: [trace], value: message, ...meta });
     }
 
     return this.logger.error(message, { context, stack: [trace] });
@@ -48,7 +48,7 @@ export class WinstonLogger implements LoggerService {
     if('object' === typeof message) {
       const { message: msg, ...meta } = message;
 
-      return this.logger.warn(msg as string, { context, ...meta });
+      return this.logger.warn(msg as string, { context, value: message, ...meta });
     }
 
     return this.logger.warn(message, { context });
@@ -60,7 +60,7 @@ export class WinstonLogger implements LoggerService {
     if('object' === typeof message) {
       const { message: msg, ...meta } = message;
 
-      return this.logger.debug(msg as string, { context, ...meta });
+      return this.logger.debug(msg as string, { context, value: message, ...meta });
     }
 
     return this.logger.debug(message, { context });
@@ -72,7 +72,7 @@ export class WinstonLogger implements LoggerService {
     if('object' === typeof message) {
       const { message: msg, ...meta } = message;
 
-      return this.logger.verbose(msg as string, { context, ...meta });
+      return this.logger.verbose(msg as string, { context, value: message, ...meta });
     }
 
     return this.logger.verbose(message, { context });


### PR DESCRIPTION
When an object or an exception is being logged, the logger tries to extract some data from it and splits the object into the message itself and some meta data. It never passes the original message object being logged to the underlying transports.

This can be an issue for some transports. For example, https://github.com/aandrewww/winston-transport-sentry-node/blob/master/src/transport.ts#L101 expects the `Error` object to be passed to the transport, so it can find the full stack trace of the exception.

This PR adds the original message being sent to Winston as a `value` property in the meta data being logged.

Please let me know what you think. I'm happy to make changes, if you think the solution could be improved.