### PR TITLE
fix: handle optional arguments of `error` properly

### DIFF
--- a/src/winston.classes.ts
+++ b/src/winston.classes.ts
@@ -23,14 +23,17 @@ export class WinstonLogger implements LoggerService {
     return this.logger.info(message, { context });
   }
 
-  public error(message: any, trace?: string, context?: string): any {
-    context = context || this.context;
+  public error(message: any, context?: string): any;
+  public error(message: any, trace?: string, context?: string): any;
+  public error(message: any, traceOrContext?: string, context?: string): any {
+    const trace = context == null ? message.stack : traceOrContext;
+    context ||= traceOrContext || this.context;
 
     if(message instanceof Error) {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { message: msg, name, stack, ...meta } = message;
 
-      return this.logger.error(msg, { context, stack: [trace || message.stack], value: message, ...meta });
+      return this.logger.error(msg, { context, stack: [trace], value: message, ...meta });
     }
 
     if('object' === typeof message) {


### PR DESCRIPTION
This PR fixes the `WinstonLogger#error` method to handle its args properly. When
a `stack` is passed as a second argument, `context` is passed as the third
argument, but if no `stack` is passed, `context` becomes the second argument
instead.

Previously, `context` wasn't displayed properly unless a `stack` argument is
passed, pushing the `context` to the third argument. The correct logic is to use
the third argument as `context` if present and the second if not. The same
applies for the `stack`: if the third argument is present, then the second is
the `stack`, otherwise no stack was passed.
