### PR TITLE
feat: add log level customization to restore winston mindset

### DIFF
--- a/src/winston.classes.ts
+++ b/src/winston.classes.ts
@@ -15,9 +15,9 @@ export class WinstonLogger implements LoggerService {
     context = context || this.context;
 
     if('object' === typeof message) {
-      const { message: msg, ...meta } = message;
+      const { message: msg, level = 'info', ...meta } = message;
 
-      return this.logger.info(msg as string, { context, value: message, ...meta });
+      return this.logger.log(level, msg as string, { context, value: message, ...meta });
     }
 
     return this.logger.info(message, { context });


### PR DESCRIPTION
Would you mind reconsidering this PR. With the current implementation there is no way to use Winston flexibility over log level implementation.
Winston documentation make this feature an assets to the library, but this nest implementation unfortunately do not give user the ability to use it. 

> ### Motivation
> ...
> 
> winston aims to decouple parts of the logging process to make it more flexible and extensible. Attention is given to supporting flexibility in log formatting (see: [Formats](https://github.com/winstonjs/winston#formats)) & levels (see: [Using custom logging levels](https://github.com/winstonjs/winston#using-custom-logging-levels)), and ensuring those APIs decoupled from the implementation of transport logging (i.e. how the logs are stored / indexed, see: [Adding Custom Transports](https://github.com/winstonjs/winston#adding-custom-transports)) to the API that they exposed to the programmer.


In the class, the logger is private and the log method state for the info level only. 

This change have no effect to the current code base and deployed projects. It give user the opportunity to personalise the log level when using the log method. They can still use other log level by using the other method. 
Also, by default the log method will use the `info` level if no level is passed to the log method. 

I hope you will consider this PR as it will restore some of Winston mindset and give us the opportunity to fully use the capabilities of this awesome libs ;)