### PR TITLE
Use options to prevent overwriting defaults with an empty object

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,8 @@ import * as winston from 'winston';
             winston.format.timestamp(),
             winston.format.ms(),
             nestWinstonModuleUtilities.format.nestLike('MyApp', {
-              // options
+              colors: true,
+              prettyPrint: true,
             }),
           ),
         }),


### PR DESCRIPTION
If empty object is passed as stated in the docs, it overwrites the default options so colors and pretty print end up disabled. 