### PR TITLE
Fix: Use transient scope for logger providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  app.useLogger(app.get(WINSTON_MODULE_NEST_PROVIDER));
+  app.useLogger(await app.resolve(WINSTON_MODULE_NEST_PROVIDER));
   await app.listen(3000);
 }
 bootstrap();

--- a/sample/replace-nest-logger/src/app.controller.ts
+++ b/sample/replace-nest-logger/src/app.controller.ts
@@ -1,14 +1,16 @@
-import { Controller, Get, Inject, LoggerService } from '@nestjs/common';
+import { Controller, Get, Inject } from '@nestjs/common';
 import { AppService } from './app.service';
-import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { WinstonLogger, WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 
 @Controller()
 export class AppController {
   constructor(
     private readonly appService: AppService,
     @Inject(WINSTON_MODULE_NEST_PROVIDER)
-    private readonly logger: LoggerService,
-  ) {}
+    private readonly logger: WinstonLogger,
+  ) {
+    this.logger.setContext('App Controller');
+  }
 
   @Get()
   getHello(): string {

--- a/sample/replace-nest-logger/src/main.ts
+++ b/sample/replace-nest-logger/src/main.ts
@@ -4,7 +4,7 @@ import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  app.useLogger(app.get(WINSTON_MODULE_NEST_PROVIDER));
+  app.useLogger(await app.resolve(WINSTON_MODULE_NEST_PROVIDER));
   await app.listen(3000);
 }
 bootstrap();

--- a/src/winston.module.spec.ts
+++ b/src/winston.module.spec.ts
@@ -12,8 +12,8 @@ describe('Winston module', function () {
       ],
     }).compile();
 
-    expect(rootModule.get(WINSTON_MODULE_PROVIDER)).toBeDefined();
-    expect(rootModule.get(WINSTON_MODULE_NEST_PROVIDER)).toBeDefined();
+    expect(await rootModule.resolve(WINSTON_MODULE_PROVIDER)).toBeDefined();
+    expect(await rootModule.resolve(WINSTON_MODULE_NEST_PROVIDER)).toBeDefined();
   });
 
   it('boots successfully asynchronously via useFactory', async function () {
@@ -41,8 +41,8 @@ describe('Winston module', function () {
     const app = rootModule.createNestApplication();
     await app.init();
 
-    expect(rootModule.get(WINSTON_MODULE_PROVIDER)).toBeDefined();
-    expect(rootModule.get(WINSTON_MODULE_NEST_PROVIDER)).toBeDefined();
+    expect(await rootModule.resolve(WINSTON_MODULE_PROVIDER)).toBeDefined();
+    expect(await rootModule.resolve(WINSTON_MODULE_NEST_PROVIDER)).toBeDefined();
   });
 
   it('boots successfully asynchronously via useClass', async function () {
@@ -66,7 +66,7 @@ describe('Winston module', function () {
     const app = rootModule.createNestApplication();
     await app.init();
 
-    expect(rootModule.get(WINSTON_MODULE_PROVIDER)).toBeDefined();
-    expect(rootModule.get(WINSTON_MODULE_NEST_PROVIDER)).toBeDefined();
+    expect(await rootModule.resolve(WINSTON_MODULE_PROVIDER)).toBeDefined();
+    expect(await rootModule.resolve(WINSTON_MODULE_NEST_PROVIDER)).toBeDefined();
   });
 });

--- a/src/winston.providers.ts
+++ b/src/winston.providers.ts
@@ -1,5 +1,5 @@
 import { Logger, LoggerOptions, createLogger } from 'winston';
-import { Provider, Type } from '@nestjs/common';
+import { Provider, Scope, Type } from '@nestjs/common';
 import { WINSTON_MODULE_NEST_PROVIDER, WINSTON_MODULE_OPTIONS, WINSTON_MODULE_PROVIDER } from './winston.constants';
 import { WinstonModuleAsyncOptions, WinstonModuleOptions, WinstonModuleOptionsFactory } from './winston.interfaces';
 import { WinstonLogger } from './winston.classes';
@@ -16,12 +16,14 @@ export function createWinstonProviders(loggerOpts: WinstonModuleOptions): Provid
     {
       provide: WINSTON_MODULE_PROVIDER,
       useFactory: () => createLogger(loggerOpts),
+      scope: Scope.TRANSIENT,
     },
     {
       provide: WINSTON_MODULE_NEST_PROVIDER,
       useFactory: (logger: Logger) => {
         return new WinstonLogger(logger);
       },
+      scope: Scope.TRANSIENT,
       inject: [WINSTON_MODULE_PROVIDER],
     },
   ];
@@ -32,6 +34,7 @@ export function createWinstonAsyncProviders(options: WinstonModuleAsyncOptions):
     {
       provide: WINSTON_MODULE_PROVIDER,
       useFactory: (loggerOpts: LoggerOptions) => createLogger(loggerOpts),
+      scope: Scope.TRANSIENT,
       inject: [WINSTON_MODULE_OPTIONS],
     },
     {
@@ -39,6 +42,7 @@ export function createWinstonAsyncProviders(options: WinstonModuleAsyncOptions):
       useFactory: (logger: Logger) => {
         return new WinstonLogger(logger);
       },
+      scope: Scope.TRANSIENT,
       inject: [WINSTON_MODULE_PROVIDER],
     },
   ];
@@ -50,6 +54,7 @@ export function createWinstonAsyncProviders(options: WinstonModuleAsyncOptions):
         provide: WINSTON_MODULE_OPTIONS,
         useFactory: async (optionsFactory: WinstonModuleOptionsFactory) =>
           await optionsFactory.createWinstonModuleOptions(),
+        scope: Scope.TRANSIENT,
         inject: [useClass],
       },
       {
@@ -64,6 +69,7 @@ export function createWinstonAsyncProviders(options: WinstonModuleAsyncOptions):
       {
         provide: WINSTON_MODULE_OPTIONS,
         useFactory: options.useFactory,
+        scope: Scope.TRANSIENT,
         inject: options.inject || [],
       },
     );


### PR DESCRIPTION
## Issue
The `logger.setContext` method doesn't work properly when it's used in multiple services because the logger provider is using default scope which is a singleton instance created on application bootstrap and the context is equal to the last `setContext` call.

## Solution
Add a transient scope to logger providers in order to create a new logger instance for every consumer class.

More info: https://docs.nestjs.com/fundamentals/injection-scopes