### PR TITLE
Add meta data transform function, fixes #626

### DIFF
--- a/src/winston.interfaces.ts
+++ b/src/winston.interfaces.ts
@@ -13,6 +13,7 @@ export type WinstonModuleOptions = LoggerOptions & {
 export type NestLikeConsoleFormatOptions = {
   colors?: boolean;
   prettyPrint?: boolean;
+  transformMeta?: (meta: Record<string, any>) => Record<string, any>;
 };
 
 export interface WinstonModuleOptionsFactory {

--- a/src/winston.utilities.ts
+++ b/src/winston.utilities.ts
@@ -45,7 +45,14 @@ const nestLikeConsoleFormat = (
     const color = options.colors && nestLikeColorScheme[level] || ((text: string): string => text);
     const yellow = options.colors ? clc.yellow : ((text: string): string => text);
 
-    const stringifiedMeta = safeStringify(meta);
+    // Apply transformation function to meta data. If no transformation function
+    // is supplied, just remove the `value` property from the meta data.
+    // https://github.com/gremo/nest-winston/issues/626
+    const transformedMeta = options.transformMeta
+      ? options.transformMeta(meta)
+      : { ...meta, value: undefined };
+
+    const stringifiedMeta = safeStringify(transformedMeta);
     const formattedMeta = options.prettyPrint
       ? inspect(JSON.parse(stringifiedMeta), { colors: options.colors, depth: null })
       : stringifiedMeta;


### PR DESCRIPTION
This PR adds a meta data transformation function that is applied before meta data is logged using the nest-like console format. By default, it removes the `value` property added in #613 .

Fixes #626 