### PR TITLE
Configurable scope

### DIFF
--- a/src/winston.interfaces.ts
+++ b/src/winston.interfaces.ts
@@ -33,4 +33,5 @@ export interface WinstonModuleAsyncOptions
   ) => Promise<WinstonModuleOptions> | WinstonModuleOptions;
   inject?: any[];
   useClass?: Type<WinstonModuleOptionsFactory>;
+  scope?: Scope;
 }

--- a/src/winston.interfaces.ts
+++ b/src/winston.interfaces.ts
@@ -1,6 +1,6 @@
-import { Scope, Type } from "@nestjs/common";
-import { ModuleMetadata } from "@nestjs/common/interfaces";
-import { Logger, LoggerOptions } from "winston";
+import { Logger, LoggerOptions } from 'winston';
+import { ModuleMetadata } from '@nestjs/common/interfaces';
+import { Scope, Type } from '@nestjs/common';
 
 export type WinstonModuleOptions = LoggerOptions & {
   /**
@@ -12,7 +12,7 @@ export type WinstonModuleOptions = LoggerOptions & {
   /**
    * Injection Scope
    */
-  scope?: Scope;
+  scope?:  Scope;
 };
 
 export type NestLikeConsoleFormatOptions = {
@@ -21,13 +21,10 @@ export type NestLikeConsoleFormatOptions = {
 };
 
 export interface WinstonModuleOptionsFactory {
-  createWinstonModuleOptions():
-    | Promise<WinstonModuleOptions>
-    | WinstonModuleOptions;
+  createWinstonModuleOptions(): Promise<WinstonModuleOptions> | WinstonModuleOptions;
 }
 
-export interface WinstonModuleAsyncOptions
-  extends Pick<ModuleMetadata, "imports"> {
+export interface WinstonModuleAsyncOptions extends Pick<ModuleMetadata, 'imports'> {
   useFactory?: (
     ...args: any[]
   ) => Promise<WinstonModuleOptions> | WinstonModuleOptions;

--- a/src/winston.interfaces.ts
+++ b/src/winston.interfaces.ts
@@ -1,6 +1,6 @@
-import { Logger, LoggerOptions } from 'winston';
-import { ModuleMetadata } from '@nestjs/common/interfaces';
-import { Type } from '@nestjs/common';
+import { Scope, Type } from "@nestjs/common";
+import { ModuleMetadata } from "@nestjs/common/interfaces";
+import { Logger, LoggerOptions } from "winston";
 
 export type WinstonModuleOptions = LoggerOptions & {
   /**
@@ -8,6 +8,11 @@ export type WinstonModuleOptions = LoggerOptions & {
    * This takes precedence on any other options provided
    */
   instance?: Logger;
+
+  /**
+   * Injection Scope
+   */
+  scope?: Scope;
 };
 
 export type NestLikeConsoleFormatOptions = {
@@ -16,10 +21,13 @@ export type NestLikeConsoleFormatOptions = {
 };
 
 export interface WinstonModuleOptionsFactory {
-  createWinstonModuleOptions(): Promise<WinstonModuleOptions> | WinstonModuleOptions;
+  createWinstonModuleOptions():
+    | Promise<WinstonModuleOptions>
+    | WinstonModuleOptions;
 }
 
-export interface WinstonModuleAsyncOptions extends Pick<ModuleMetadata, 'imports'> {
+export interface WinstonModuleAsyncOptions
+  extends Pick<ModuleMetadata, "imports"> {
   useFactory?: (
     ...args: any[]
   ) => Promise<WinstonModuleOptions> | WinstonModuleOptions;

--- a/src/winston.providers.ts
+++ b/src/winston.providers.ts
@@ -16,6 +16,7 @@ export function createWinstonProviders(loggerOpts: WinstonModuleOptions): Provid
     {
       provide: WINSTON_MODULE_PROVIDER,
       useFactory: () => createLogger(loggerOpts),
+      scope: loggerOpts.scope
     },
     {
       provide: WINSTON_MODULE_NEST_PROVIDER,
@@ -23,6 +24,7 @@ export function createWinstonProviders(loggerOpts: WinstonModuleOptions): Provid
         return new WinstonLogger(logger);
       },
       inject: [WINSTON_MODULE_PROVIDER],
+      scope: loggerOpts.scope
     },
   ];
 }
@@ -33,6 +35,7 @@ export function createWinstonAsyncProviders(options: WinstonModuleAsyncOptions):
       provide: WINSTON_MODULE_PROVIDER,
       useFactory: (loggerOpts: LoggerOptions) => createLogger(loggerOpts),
       inject: [WINSTON_MODULE_OPTIONS],
+      scope: options.scope
     },
     {
       provide: WINSTON_MODULE_NEST_PROVIDER,
@@ -40,6 +43,7 @@ export function createWinstonAsyncProviders(options: WinstonModuleAsyncOptions):
         return new WinstonLogger(logger);
       },
       inject: [WINSTON_MODULE_PROVIDER],
+      scope: options.scope
     },
   ];
 
@@ -51,6 +55,7 @@ export function createWinstonAsyncProviders(options: WinstonModuleAsyncOptions):
         useFactory: async (optionsFactory: WinstonModuleOptionsFactory) =>
           await optionsFactory.createWinstonModuleOptions(),
         inject: [useClass],
+        scope: options.scope
       },
       {
         provide: useClass,
@@ -65,6 +70,7 @@ export function createWinstonAsyncProviders(options: WinstonModuleAsyncOptions):
         provide: WINSTON_MODULE_OPTIONS,
         useFactory: options.useFactory,
         inject: options.inject || [],
+        scope: options.scope
       },
     );
   }


### PR DESCRIPTION
Hello,

following discussion on issue #610 and #122 I tried to make a PR to address the need to have a configurable scope. I've also looked at #633 but I think the scope should be user defined and not changed to `TRANSIENT` by default.

Please let me know if tests and/or sample are also needed.