### PR TITLE
fix: pass nullish messages to winston directly

### DIFF
--- a/src/winston.classes.ts
+++ b/src/winston.classes.ts
@@ -14,7 +14,7 @@ export class WinstonLogger implements LoggerService {
   public log(message: any, context?: string): any {
     context = context || this.context;
 
-    if('object' === typeof message) {
+    if(!!message && 'object' === typeof message) {
       const { message: msg, level = 'info', ...meta } = message;
 
       return this.logger.log(level, msg as string, { context, ...meta });
@@ -33,7 +33,7 @@ export class WinstonLogger implements LoggerService {
       return this.logger.error(msg, { context, stack: [trace || message.stack], error: message, ...meta });
     }
 
-    if('object' === typeof message) {
+    if(!!message && 'object' === typeof message) {
       const { message: msg, ...meta } = message;
 
       return this.logger.error(msg as string, { context, stack: [trace], ...meta });
@@ -45,7 +45,7 @@ export class WinstonLogger implements LoggerService {
   public warn(message: any, context?: string): any {
     context = context || this.context;
 
-    if('object' === typeof message) {
+    if(!!message && 'object' === typeof message) {
       const { message: msg, ...meta } = message;
 
       return this.logger.warn(msg as string, { context, ...meta });
@@ -57,7 +57,7 @@ export class WinstonLogger implements LoggerService {
   public debug?(message: any, context?: string): any {
     context = context || this.context;
 
-    if('object' === typeof message) {
+    if(!!message && 'object' === typeof message) {
       const { message: msg, ...meta } = message;
 
       return this.logger.debug(msg as string, { context, ...meta });
@@ -69,7 +69,7 @@ export class WinstonLogger implements LoggerService {
   public verbose?(message: any, context?: string): any {
     context = context || this.context;
 
-    if('object' === typeof message) {
+    if(!!message && 'object' === typeof message) {
       const { message: msg, ...meta } = message;
 
       return this.logger.verbose(msg as string, { context, ...meta });


### PR DESCRIPTION
Fixes #593

Since `winston@3.0.0`, passing `null` or `undefined` to the winston instance is supported.

```typescript
logger.log(undefined);
logger.log(null);
```
(see https://github.com/winstonjs/winston/issues/1290)

However, `nest-winston` seems to be miss-handling those type of messages with the following: 

```typescript
if('object' === typeof message) { // `undefined` and `null` are of type 'object'
  const { message: msg, level = 'info', ...meta } = message; // throws 'Cannot destructure property'

   return this.logger.log(level, msg as string, { context, ...meta });
}

return this.logger.info(message, { context });
```

This fix proposes to failback to the winston native logger :  

```typescript
if(!!message && 'object' === typeof message) { // only non-nullish objects
  const { message: msg, level = 'info', ...meta } = message; // won't throw

   return this.logger.log(level, msg as string, { context, ...meta });
}

return this.logger.info(message, { context });
```
