### PR TITLE
chore: adjust CI to respect nestjs 10 dropping EOL node versions

### DIFF
--- a/.github/workflows/test-on-push.yml
+++ b/.github/workflows/test-on-push.yml
@@ -9,8 +9,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['12', '14', '16']
-        nest-version: ['5', '6', '7', '8', '']
+        node-version: ['16', '18']
+        nest-version: ['5', '6', '7', '8', '9', '']
         include:
           - { node-version: '8.9.0', nest-version: '5' }
           - { node-version: '8.9.0', nest-version: '6' }
@@ -19,6 +19,16 @@ jobs:
           - { node-version: '10', nest-version: '6' }
           - { node-version: '10', nest-version: '7' }
           - { node-version: '10', nest-version: '8' }
+          - { node-version: '12', nest-version: '5' }
+          - { node-version: '12', nest-version: '6' }
+          - { node-version: '12', nest-version: '7' }
+          - { node-version: '12', nest-version: '8' }
+          - { node-version: '12', nest-version: '9' }
+          - { node-version: '14', nest-version: '5' }
+          - { node-version: '14', nest-version: '6' }
+          - { node-version: '14', nest-version: '7' }
+          - { node-version: '14', nest-version: '8' }
+          - { node-version: '14', nest-version: '9' }
 
     steps:
       - name: Checkout
@@ -44,7 +54,8 @@ jobs:
         if: >-
           startsWith(matrix.nest-version, '6') ||
           startsWith(matrix.nest-version, '7') ||
-          startsWith(matrix.nest-version, '8')
+          startsWith(matrix.nest-version, '8') ||
+          startsWith(matrix.nest-version, '9')
         run: npm install @nestjs/platform-express@^${{ matrix.nest-version }}
 
       # nestjs 5.x-7.x supports rxjs 6.x

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,10 @@
         "fast-safe-stringify": "^2.1.1"
       },
       "devDependencies": {
-        "@nestjs/common": "9.4.3",
-        "@nestjs/core": "9.4.3",
-        "@nestjs/platform-express": "9.4.3",
-        "@nestjs/testing": "9.4.3",
+        "@nestjs/common": "10.0.2",
+        "@nestjs/core": "10.0.2",
+        "@nestjs/platform-express": "10.0.2",
+        "@nestjs/testing": "10.0.2",
         "@types/jest": "29.5.2",
         "@typescript-eslint/eslint-plugin": "5.59.11",
         "@typescript-eslint/parser": "5.59.11",
@@ -31,7 +31,7 @@
         "winston": "3.9.0"
       },
       "peerDependencies": {
-        "@nestjs/common": "^5.0.0 || ^6.6.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
+        "@nestjs/common": "^5.0.0 || ^6.6.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
         "winston": "^3.0.0"
       }
     },
@@ -1096,9 +1096,9 @@
       }
     },
     "node_modules/@nestjs/common": {
-      "version": "9.4.3",
-      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-9.4.3.tgz",
-      "integrity": "sha512-Gd6D4IaYj01o14Bwv81ukidn4w3bPHCblMUq+SmUmWLyosK+XQmInCS09SbDDZyL8jy86PngtBLTdhJ2bXSUig==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.0.2.tgz",
+      "integrity": "sha512-pws0Xtlt6olOleJiMH1/QxKYjV4eZbNMBvVrBraCmKMnrLG2HcVPlANuyPWOB18sz5s8u5/qCKJxuuP9uNIRqQ==",
       "dev": true,
       "dependencies": {
         "iterare": "1.2.1",
@@ -1110,16 +1110,12 @@
         "url": "https://opencollective.com/nest"
       },
       "peerDependencies": {
-        "cache-manager": "<=5",
         "class-transformer": "*",
         "class-validator": "*",
         "reflect-metadata": "^0.1.12",
         "rxjs": "^7.1.0"
       },
       "peerDependenciesMeta": {
-        "cache-manager": {
-          "optional": true
-        },
         "class-transformer": {
           "optional": true
         },
@@ -1135,9 +1131,9 @@
       "dev": true
     },
     "node_modules/@nestjs/core": {
-      "version": "9.4.3",
-      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-9.4.3.tgz",
-      "integrity": "sha512-Qi63+wi55Jh4sDyaj5Hhx2jOpKqT386aeo+VOKsxnd+Ql9VvkO/FjmuwBGUyzkJt29ENYc+P0Sx/k5LtstNpPQ==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.0.2.tgz",
+      "integrity": "sha512-Z84z7xJ5n6Noffl8brT7Z2tuW6pP46zWJk8NECSyon5iGQti+QemkE7lkx/MiCTe9oCB0L/S30UR8A2bAbOfDg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -1153,10 +1149,10 @@
         "url": "https://opencollective.com/nest"
       },
       "peerDependencies": {
-        "@nestjs/common": "^9.0.0",
-        "@nestjs/microservices": "^9.0.0",
-        "@nestjs/platform-express": "^9.0.0",
-        "@nestjs/websockets": "^9.0.0",
+        "@nestjs/common": "^10.0.0",
+        "@nestjs/microservices": "^10.0.0",
+        "@nestjs/platform-express": "^10.0.0",
+        "@nestjs/websockets": "^10.0.0",
         "reflect-metadata": "^0.1.12",
         "rxjs": "^7.1.0"
       },
@@ -1179,9 +1175,9 @@
       "dev": true
     },
     "node_modules/@nestjs/platform-express": {
-      "version": "9.4.3",
-      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-9.4.3.tgz",
-      "integrity": "sha512-FpdczWoRSC0zz2dNL9u2AQLXKXRVtq4HgHklAhbL59X0uy+mcxhlSThG7DHzDMkoSnuuHY8ojDVf7mDxk+GtCw==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.0.2.tgz",
+      "integrity": "sha512-VfPkstVqdeLkIrc/U1vyAO2OebV+myPgxv4vgxdvSSf6rSOWwqmTaWA6zHjZA5CYCmNf5cTGVXugCwz8cvn5KA==",
       "dev": true,
       "dependencies": {
         "body-parser": "1.20.2",
@@ -1195,8 +1191,8 @@
         "url": "https://opencollective.com/nest"
       },
       "peerDependencies": {
-        "@nestjs/common": "^9.0.0",
-        "@nestjs/core": "^9.0.0"
+        "@nestjs/common": "^10.0.0",
+        "@nestjs/core": "^10.0.0"
       }
     },
     "node_modules/@nestjs/platform-express/node_modules/body-parser": {
@@ -1260,9 +1256,9 @@
       "dev": true
     },
     "node_modules/@nestjs/testing": {
-      "version": "9.4.3",
-      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-9.4.3.tgz",
-      "integrity": "sha512-LDT8Ai2eKnTzvnPaJwWOK03qTaFap5uHHsJCv6dL0uKWk6hyF9jms8DjyVaGsaujCaXDG8izl1mDEER0OmxaZA==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-10.0.2.tgz",
+      "integrity": "sha512-Fjj5dGcAW0MSvZI3RzVhZtGU49ZOYysHyOx8spOXWeu2jDr4B+ChkAYJDuZSx9U0x/1ONp3RNZau6gWgG8UO9w==",
       "dev": true,
       "dependencies": {
         "tslib": "2.5.3"
@@ -1272,10 +1268,10 @@
         "url": "https://opencollective.com/nest"
       },
       "peerDependencies": {
-        "@nestjs/common": "^9.0.0",
-        "@nestjs/core": "^9.0.0",
-        "@nestjs/microservices": "^9.0.0",
-        "@nestjs/platform-express": "^9.0.0"
+        "@nestjs/common": "^10.0.0",
+        "@nestjs/core": "^10.0.0",
+        "@nestjs/microservices": "^10.0.0",
+        "@nestjs/platform-express": "^10.0.0"
       },
       "peerDependenciesMeta": {
         "@nestjs/microservices": {
@@ -7254,9 +7250,9 @@
       "dev": true
     },
     "@nestjs/common": {
-      "version": "9.4.3",
-      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-9.4.3.tgz",
-      "integrity": "sha512-Gd6D4IaYj01o14Bwv81ukidn4w3bPHCblMUq+SmUmWLyosK+XQmInCS09SbDDZyL8jy86PngtBLTdhJ2bXSUig==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.0.2.tgz",
+      "integrity": "sha512-pws0Xtlt6olOleJiMH1/QxKYjV4eZbNMBvVrBraCmKMnrLG2HcVPlANuyPWOB18sz5s8u5/qCKJxuuP9uNIRqQ==",
       "dev": true,
       "requires": {
         "iterare": "1.2.1",
@@ -7273,9 +7269,9 @@
       }
     },
     "@nestjs/core": {
-      "version": "9.4.3",
-      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-9.4.3.tgz",
-      "integrity": "sha512-Qi63+wi55Jh4sDyaj5Hhx2jOpKqT386aeo+VOKsxnd+Ql9VvkO/FjmuwBGUyzkJt29ENYc+P0Sx/k5LtstNpPQ==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.0.2.tgz",
+      "integrity": "sha512-Z84z7xJ5n6Noffl8brT7Z2tuW6pP46zWJk8NECSyon5iGQti+QemkE7lkx/MiCTe9oCB0L/S30UR8A2bAbOfDg==",
       "dev": true,
       "requires": {
         "@nuxtjs/opencollective": "0.3.2",
@@ -7295,9 +7291,9 @@
       }
     },
     "@nestjs/platform-express": {
-      "version": "9.4.3",
-      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-9.4.3.tgz",
-      "integrity": "sha512-FpdczWoRSC0zz2dNL9u2AQLXKXRVtq4HgHklAhbL59X0uy+mcxhlSThG7DHzDMkoSnuuHY8ojDVf7mDxk+GtCw==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.0.2.tgz",
+      "integrity": "sha512-VfPkstVqdeLkIrc/U1vyAO2OebV+myPgxv4vgxdvSSf6rSOWwqmTaWA6zHjZA5CYCmNf5cTGVXugCwz8cvn5KA==",
       "dev": true,
       "requires": {
         "body-parser": "1.20.2",
@@ -7363,9 +7359,9 @@
       }
     },
     "@nestjs/testing": {
-      "version": "9.4.3",
-      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-9.4.3.tgz",
-      "integrity": "sha512-LDT8Ai2eKnTzvnPaJwWOK03qTaFap5uHHsJCv6dL0uKWk6hyF9jms8DjyVaGsaujCaXDG8izl1mDEER0OmxaZA==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-10.0.2.tgz",
+      "integrity": "sha512-Fjj5dGcAW0MSvZI3RzVhZtGU49ZOYysHyOx8spOXWeu2jDr4B+ChkAYJDuZSx9U0x/1ONp3RNZau6gWgG8UO9w==",
       "dev": true,
       "requires": {
         "tslib": "2.5.3"

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
     "fast-safe-stringify": "^2.1.1"
   },
   "devDependencies": {
-    "@nestjs/common": "9.4.3",
-    "@nestjs/core": "9.4.3",
-    "@nestjs/platform-express": "9.4.3",
-    "@nestjs/testing": "9.4.3",
+    "@nestjs/common": "10.0.2",
+    "@nestjs/core": "10.0.2",
+    "@nestjs/platform-express": "10.0.2",
+    "@nestjs/testing": "10.0.2",
     "@types/jest": "29.5.2",
     "@typescript-eslint/eslint-plugin": "5.59.11",
     "@typescript-eslint/parser": "5.59.11",
@@ -43,7 +43,7 @@
     "winston": "3.9.0"
   },
   "peerDependencies": {
-    "@nestjs/common": "^5.0.0 || ^6.6.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
+    "@nestjs/common": "^5.0.0 || ^6.6.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
     "winston": "^3.0.0"
   },
   "homepage": "https://github.com/gremo/nest-winston#readme",


### PR DESCRIPTION
In the [NestJS 10 Release](https://github.com/nestjs/nest/releases/tag/v10.0.0) it was announced that the supported node.js versions are >= 16. 
Adjusted the CI, so it runs again and the tests run properly only on supported versions. :)

Closes #682