### PR TITLE
made nestLike output closer to nestjs

### DIFF
--- a/src/winston.utilities.ts
+++ b/src/winston.utilities.ts
@@ -14,7 +14,7 @@ const clc = {
 };
 
 const nestLikeColorScheme: Record<string, (text: string) => string> = {
-  info: clc.green,
+  log: clc.green,
   error: clc.red,
   warn: clc.yellow,
   debug: clc.magentaBright,
@@ -29,6 +29,10 @@ const nestLikeConsoleFormat = (
   },
 ): Format =>
   format.printf(({ context, level, timestamp, message, ms, ...meta }) => {
+    if ('info' === level) {
+      level = 'log';
+    }
+
     if ('undefined' !== typeof timestamp) {
       // Only format the timestamp to a locale representation if it's ISO 8601 format. Any format
       // that is not a valid date string will throw, just ignore it (it will be printed as-is).
@@ -51,9 +55,9 @@ const nestLikeConsoleFormat = (
       : stringifiedMeta;
 
     return (
-      `${color(`[${appName}]`)} ` +
-      `${yellow(level.charAt(0).toUpperCase() + level.slice(1))}\t` +
+      color(`[${appName}] ${String(process.pid).padEnd(6)} - `) +
       ('undefined' !== typeof timestamp ? `${timestamp} ` : '') +
+      `${color(level.toUpperCase().padStart(7))}\t` +
       ('undefined' !== typeof context
         ? `${yellow('[' + context + ']')} `
         : '') +


### PR DESCRIPTION
#### 🔧 Types of changes

Please explain the changes you made here.

*Put an `x` in the boxes that apply (you can also fill these out after creating the PR).*

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Codebase improvement
- [ ] Other (if none of the other choices apply)

#### 🚨 Checklist

Your checklist for this pull request.

*Put an `x` in the boxes that apply (you can also fill these out after creating the PR).*

- [x] I've read the [guidelines for contributing](https://github.com/gremo/nest-winsto/blob/main/CONTRIBUTING.md)
- [ ] I've added necessary documentation (if appropriate)
- [x] I've ensured that my code additions do not fail linting or unit tests (if applicable)

#### Description

This is how nestjs formats logs:

```
[Nest] 33476  - 11/22/2023, 10:19:55 AM     LOG [NestFactory] Starting Nest application...
```

this is how the `format.nestLike` option used to format logs:

```
[Nest] Info     11/22/2023, 11:27:24 AM [NestFactory] Starting Nest application...
```

this is how it formats it with the current change:

```
[Nest] 52605  - 11/22/2023, 11:31:43 AM     LOG [NestFactory] Starting Nest application...
```

which aligns perfectly now.