### PR TITLE
Feature: Fatal logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ export class AppModule {}
 debug(message: any, context?: string)
 log(message: any, context?: string)
 error(message: any, stack?: string, context?: string)
+fatal(message: any, stack?: string, context?: string)
 verbose(message: any, context?: string)
 warn(message: any, context?: string)
 ```

--- a/src/winston.classes.ts
+++ b/src/winston.classes.ts
@@ -23,6 +23,25 @@ export class WinstonLogger implements LoggerService {
     return this.logger.info(message, { context });
   }
 
+  public fatal(message: any, trace?: string, context?: string): any {
+    context = context || this.context;
+
+    if (message instanceof Error) {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { message: msg, name, stack, ...meta } = message;
+
+      return this.logger.log({ level: 'fatal', message: msg, context, stack: [trace || stack], error: message, ...meta });
+    }
+
+    if (!!message && 'object' === typeof message) {
+      const { message: msg, ...meta } = message;
+
+      return this.logger.error({ level: 'fatal', message: msg, context, stack: [trace], ...meta });
+    }
+
+    return this.logger.error({ level: 'fatal', message, context, stack: [trace] });
+  }
+
   public error(message: any, trace?: string, context?: string): any {
     context = context || this.context;
 


### PR DESCRIPTION
#### 🔧 Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update
- [ ] Codebase improvement
- [ ] Other (if none of the other choices apply)

#### 🚨 Checklist

- [X] I've read the [guidelines for contributing](https://github.com/gremo/nest-winsto/blob/main/CONTRIBUTING.md)
- [X] I've added necessary documentation (if appropriate)
- [X] I've ensured that my code additions do not fail linting or unit tests (if applicable)

#### Description

This PR introduces log level `fatal` to ensure feature-parity with the newest NestJS version (discussed in #727).
The code implemented is a simple copy-and-paste from `WinstonLogger#error`, adjusting the log level to `fatal`

This is NOT a breaking change as older NestJS projects will simply not use the method by default (completions wont show, logger won't log, though calling the method forcefully will still work).
