### PR TITLE
Fix: avoid undefined message in utilities

### DIFF
--- a/src/winston.utilities.ts
+++ b/src/winston.utilities.ts
@@ -59,9 +59,9 @@ const nestLikeConsoleFormat = (
       ('undefined' !== typeof timestamp ? `${timestamp} ` : '') +
       `${color(level.toUpperCase().padStart(7))} ` +
       ('undefined' !== typeof context
-        ? `${yellow('[' + context + ']')} `
+        ? `${yellow('[' + context + ']')}`
         : '') +
-      `${color(message)}` +
+      ('undefined' !== typeof message ? ` ${color(message)}` : '') +
       (formattedMeta && formattedMeta !== '{}' ? ` - ${formattedMeta}` : '') +
       ('undefined' !== typeof ms ? ` ${yellow(ms)}` : '')
     );


### PR DESCRIPTION
#### 🔧 Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Codebase improvement
- [ ] Other (if none of the other choices apply)

#### 🚨 Checklist

- [x] I've read the [guidelines for contributing](https://github.com/gremo/nest-winston/blob/main/CONTRIBUTING.md)
- [x] I've added necessary documentation (if appropriate)
- [x] I've ensured that my code additions do not fail linting or unit tests (if applicable)

#### Description
When we use logger at interceptor without message, and attach an object directly into `.log` function such as:
```ts
this.logger.log(
  {
   // message: "it should be here, but i wanna try without this field to reproduce undefined case."
    fields: {
      method: "GET",
      userAgent: "my-ua",
      ...
    },
  },
  context.getClass().name
);
```


The output in console transport will appear `undefined` due to message is undefined : 
```
[NESTJS] Info 4/24/2024, 3:36:42 PM [MyController] undefined - {
  fields: {
     method: "GET",
     userAgent: "my-ua",
} +2m
```

Therefore, this PR that simple check `message` variable before it can appear in the console.