### PR TITLE
Optional Process ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ The module also provides a custom Nest-like special formatter for console transp
 
 - `colors`: enable console colors, defaults to `true`, unless `process.env.NO_COLOR` is set (same behaviour of Nest > 7.x)
 - `prettyPrint`: pretty format log metadata, defaults to `true`
+- `processId`: includes the Node Process ID (`process.pid`) in the output, defaults to `true`
 
 ```typescript
 import { Module } from '@nestjs/common';
@@ -267,6 +268,7 @@ import * as winston from 'winston';
             nestWinstonModuleUtilities.format.nestLike('MyApp', {
               colors: true,
               prettyPrint: true,
+              processId: true
             }),
           ),
         }),

--- a/src/winston.interfaces.ts
+++ b/src/winston.interfaces.ts
@@ -13,6 +13,7 @@ export type WinstonModuleOptions = LoggerOptions & {
 export type NestLikeConsoleFormatOptions = {
   colors?: boolean;
   prettyPrint?: boolean;
+  processId?: boolean;
 };
 
 export interface WinstonModuleOptionsFactory {

--- a/src/winston.utilities.ts
+++ b/src/winston.utilities.ts
@@ -26,6 +26,7 @@ const nestLikeConsoleFormat = (
   options: NestLikeConsoleFormatOptions = {
     colors: !process.env.NO_COLOR,
     prettyPrint: false,
+    processId: true,
   },
 ): Format =>
   format.printf(({ context, level, timestamp, message, ms, ...meta }) => {
@@ -55,7 +56,7 @@ const nestLikeConsoleFormat = (
       : stringifiedMeta;
 
     return (
-      color(`[${appName}] ${String(process.pid).padEnd(6)} - `) +
+      color(`[${appName}] ${options.processId ? String(process.pid).padEnd(6) + ' ' : ''}- `) +
       ('undefined' !== typeof timestamp ? `${timestamp} ` : '') +
       `${color(level.toUpperCase().padStart(7))} ` +
       ('undefined' !== typeof context


### PR DESCRIPTION
#### 🔧 Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update
- [ ] Codebase improvement
- [ ] Other (if none of the other choices apply)

#### 🚨 Checklist

Your checklist for this pull request.

*Put an `x` in the boxes that apply (you can also fill these out after creating the PR).*

- [x] I've read the [guidelines for contributing](https://github.com/gremo/nest-winsto/blob/main/CONTRIBUTING.md)
- [x] I've added necessary documentation (if appropriate)
- [x] I've ensured that my code additions do not fail linting or unit tests (if applicable)

#### Description
Adding a new option when setting the `format.nestLike` options. A new `processID` option, which defaults to `true` to keep the same default behavior. When set to `false` the process ID is omitted from the output

`processID: true`
```
[NestJS] 7568   - 5/20/2024, 3:20:09 PM     LOG [NestApplication] Nest application successfully started +0ms
```
`processID: false`
```
[NestJS] - 5/20/2024, 3:20:09 PM     LOG [NestApplication] Nest application successfully started +0ms
```