### PR TITLE
feat(utilities): Allow optional app name display for nest-like console formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ The module also provides a custom Nest-like special formatter for console transp
 - `colors`: enable console colors, defaults to `true`, unless `process.env.NO_COLOR` is set (same behaviour of Nest > 7.x)
 - `prettyPrint`: pretty format log metadata, defaults to `true`
 - `processId`: includes the Node Process ID (`process.pid`) in the output, defaults to `true`
+- `appName`: includes the provided application name in the output, defaults to `true`
 
 ```typescript
 import { Module } from '@nestjs/common';
@@ -268,7 +269,8 @@ import * as winston from 'winston';
             nestWinstonModuleUtilities.format.nestLike('MyApp', {
               colors: true,
               prettyPrint: true,
-              processId: true
+              processId: true,
+              appName: true,
             }),
           ),
         }),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nest-winston",
-  "version": "1.10.6",
+  "version": "1.9.6",
   "license": "MIT",
   "description": "A Nest module wrapper for winston",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nest-winston",
-  "version": "1.9.6",
+  "version": "1.10.6",
   "license": "MIT",
   "description": "A Nest module wrapper for winston",
   "keywords": [

--- a/src/winston.interfaces.ts
+++ b/src/winston.interfaces.ts
@@ -14,6 +14,7 @@ export type NestLikeConsoleFormatOptions = {
   colors?: boolean;
   prettyPrint?: boolean;
   processId?: boolean;
+  appName?: boolean;
 };
 
 export interface WinstonModuleOptionsFactory {

--- a/src/winston.utilities.ts
+++ b/src/winston.utilities.ts
@@ -27,6 +27,7 @@ const nestLikeConsoleFormat = (
     colors: !process.env.NO_COLOR,
     prettyPrint: false,
     processId: true,
+    appName: true,
   },
 ): Format =>
   format.printf(({ context, level, timestamp, message, ms, ...meta }) => {
@@ -56,7 +57,8 @@ const nestLikeConsoleFormat = (
       : stringifiedMeta;
 
     return (
-      color(`[${appName}] ${options.processId ? String(process.pid).padEnd(6) + ' ' : ''}- `) +
+      (options.appName ? color(`[${appName}]`) + ' ' :  '') +
+      (options.processId ? color(String(process.pid)).padEnd(6) + ' ' : '') +
       ('undefined' !== typeof timestamp ? `${timestamp} ` : '') +
       `${color(level.toUpperCase().padStart(7))} ` +
       ('undefined' !== typeof context


### PR DESCRIPTION
#### 🔧 Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Codebase improvement
- [ ] Other (if none of the other choices apply)

#### 🚨 Checklist

Your checklist for this pull request.

*Put an `x` in the boxes that apply (you can also fill these out after creating the PR).*

- [x] I've read the [guidelines for contributing](https://github.com/gremo/nest-winsto/blob/main/CONTRIBUTING.md)
- [x] I've added necessary documentation (if appropriate)
- [x] I've ensured that my code additions do not fail linting or unit tests (if applicable)

#### Description

Allowed for Nest-like console formatting to optionally display an application name.
