### PR TITLE
Add WinstonLogger.setLogLevels

### DIFF
--- a/src/winston.classes.ts
+++ b/src/winston.classes.ts
@@ -100,4 +100,25 @@ export class WinstonLogger implements LoggerService {
   public getWinstonLogger(): Logger {
     return this.logger;
   }
+
+  public setLogLevels(names: string[]) {
+    const namesWithLevels: [string, number][] = names
+      .map<[string, number]>(name => {
+      const level = this.logger.levels[name] || undefined;
+
+      // Guard against invalid log levels
+      if (level === undefined) {
+        throw new Error(
+          `Invalid log level ${level}, must be one of ${Object.keys(
+            this.logger.levels,
+          )}`,
+        );
+      }
+
+      return [name, level];
+    })
+      .sort((a, b) => b[1] - a[1]); // sort by level, highest first
+
+    this.logger.level = namesWithLevels[0][0];
+  }
 }


### PR DESCRIPTION
#### 🔧 Types of changes

Please explain the changes you made here.

*Put an `x` in the boxes that apply (you can also fill these out after creating the PR).*

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Codebase improvement
- [ ] Other (if none of the other choices apply)

#### 🚨 Checklist

Your checklist for this pull request.

*Put an `x` in the boxes that apply (you can also fill these out after creating the PR).*

- [x] I've read the [guidelines for contributing](https://github.com/gremo/nest-winsto/blob/main/CONTRIBUTING.md)
- [x] I've added necessary documentation (if appropriate)
- [x] I've ensured that my code additions do not fail linting or unit tests (if applicable)

#### Description

This method is used by NestJS when calling Logger.overrideLogger with an array of log level names.

Ref. #368 #519
