### PR TITLE
fix: fatal level not preserved with json format logs

### DIFF
--- a/src/winston.classes.ts
+++ b/src/winston.classes.ts
@@ -36,10 +36,10 @@ export class WinstonLogger implements LoggerService {
     if (!!message && 'object' === typeof message) {
       const { message: msg, ...meta } = message;
 
-      return this.logger.error({ level: 'fatal', message: msg, context, stack: [trace], ...meta });
+      return this.logger.log({ level: 'fatal', message: msg, context, stack: [trace], ...meta });
     }
 
-    return this.logger.error({ level: 'fatal', message, context, stack: [trace] });
+    return this.logger.log({ level: 'fatal', message, context, stack: [trace] });
   }
 
   public error(message: any, trace?: string, context?: string): any {


### PR DESCRIPTION
### Description

When logging a fatal message using NestJs Logger, the level is changed to error.

This specifically happens when using json format in winston.

Example:
```ts
import { WinstonModule, WinstonModuleOptions } from 'nest-winston';
import winston from 'winston';

// configuring winston module
const winstonConfig: WinstonModuleOptions = {
  levels: {
    fatal: 0,
    error: 1,
    warn: 2,
    info: 3,
    debug: 4,
    verbose: 5,
  },
  level: 'verbose',
  transports: [
    new winston.transports.Console({
      format: winston.format.json(),
    }),
  ],
};

export const winstonLogger = WinstonModule.createLogger(winstonConfig);

// Configuring NestJs to use Winston logger
...
const app = await NestFactory.create(AppModule, {
  logger: winstonLogger,
});

// Logging a fatal message
import { Logger } from '@nestjs/common';
Logger.fatal('some fatal error');
```

The example above produces a json log with error level, because of using `logger.error`:
```
{"level":"error","message":"some fatal error","stack":[null]}
```

Replacing `logger.error` with `logger.log` resolves this issue, resulting the desired log:
```
{"level":"fatal","message":"some fatal error","stack":[null]}
```

I hope this example explaines the situation, I faced this issue in my work & certainly don't have time to create a repo for demonstrating the error. 

#### 🔧 Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Codebase improvement
- [ ] Other (if none of the other choices apply)

#### 🚨 Checklist

Your checklist for this pull request.

*Put an `x` in the boxes that apply (you can also fill these out after creating the PR).*

- [x] I've read the [guidelines for contributing](https://github.com/gremo/nest-winsto/blob/main/CONTRIBUTING.md)
- [ ] I've added necessary documentation (if appropriate)
- [x] I've ensured that my code additions do not fail linting or unit tests (if applicable)